### PR TITLE
Create simple way to leverage bulk

### DIFF
--- a/bulk/formatter.go
+++ b/bulk/formatter.go
@@ -39,7 +39,6 @@ func NewFormatter(job *Job, fields []string) (*Formatter, error) {
 	}
 	if _, err := f.sb.WriteString(job.newline()); err != nil {
 		return nil, err
-
 	}
 
 	return f, nil
@@ -52,22 +51,7 @@ func (f *Formatter) Add(records ...Record) error {
 	}
 
 	for _, record := range records {
-		recFields := record.Fields()
-		values := make([]string, len(f.fields))
-		insertNull := record.InsertNull()
-		for idx, field := range f.fields {
-			if insertNull {
-				values[idx] = "#N/A"
-			} else {
-				values[idx] = ""
-			}
-			if value, ok := recFields[field]; ok {
-				if value != nil {
-					values[idx] = fmt.Sprintf("%v", value)
-				}
-			}
-		}
-		_, err := f.sb.WriteString(strings.Join(values, f.job.delimiter()))
+		_, err := f.sb.WriteString(f.buildRecordString(record))
 		if err != nil {
 			return err
 		}
@@ -79,6 +63,25 @@ func (f *Formatter) Add(records ...Record) error {
 	}
 
 	return nil
+}
+
+func (f *Formatter) buildRecordString(record Record) string {
+	recFields := record.Fields()
+	values := make([]string, len(f.fields))
+	insertNull := record.InsertNull()
+	for idx, field := range f.fields {
+		if insertNull {
+			values[idx] = "#N/A"
+		} else {
+			values[idx] = ""
+		}
+		if value, ok := recFields[field]; ok {
+			if value != nil {
+				values[idx] = fmt.Sprintf("%v", value)
+			}
+		}
+	}
+	return strings.Join(values, f.job.delimiter())
 }
 
 // Reader will return a reader of the bulk uploader field record body.

--- a/bulk/job_simple.go
+++ b/bulk/job_simple.go
@@ -1,0 +1,117 @@
+package bulk
+
+import (
+	"io/ioutil"
+
+	b64 "encoding/base64"
+
+	"github.com/g8rswimmer/go-sfdc/session"
+)
+
+const (
+	// A request can provide CSV data that does not in total exceed 150 MB of base64 encoded content.
+	// https://developer.salesforce.com/docs/atlas.en-us.api_bulk_v2.meta/api_bulk_v2/upload_job_data.htm
+	maxUploadSizeBytes = 150000000 // I think Salesforce is using this number and not the actual 150MB byte value
+)
+
+// ProcessDataAsBulkJobs recieves all the necessary information to upload large amounts of data
+// breaking it into individual jobs as needed if they cross the size threshold, returns the created jobs
+func ProcessDataAsBulkJobs(session session.ServiceFormatter, options Options, fields []string, data []Record) ([]*Job, error) {
+	// Get an initial job
+	jobs := []*Job{}
+	j, err := openBulkJob(session, options)
+	if err != nil {
+		return jobs, err
+	}
+	jobs = append(jobs, j)
+
+	f, err := NewFormatter(j, fields)
+	if err != nil {
+		return jobs, err
+	}
+	// Get the by counts of the headers and the line encoding
+	headers, err := ioutil.ReadAll(f.Reader())
+	if err != nil {
+		return jobs, err
+	}
+	sizeOfHeaders := len(b64.StdEncoding.EncodeToString(headers))
+	sizeOfLineEnding := len(b64.StdEncoding.EncodeToString([]byte(options.LineEnding)))
+
+	// loop through output from records, analyze the impact of adding another record to the total CSV size
+	rollingSize := sizeOfHeaders + sizeOfLineEnding
+	rollingRowCount := 0
+	for _, v := range data {
+
+		// get size of encoded data for this row
+		sizeOfRow := len(b64.StdEncoding.EncodeToString([]byte(f.buildRecordString(v))))
+		rollingSize += sizeOfRow + sizeOfLineEnding
+		// if the new record would push it over the threshold send the CSV to the open job and start a new one
+		if rollingSize > maxUploadSizeBytes {
+			// Send the data, close the job, start a new job, make a new formatter, do it again
+			err := sendDataToJob(j, f)
+			if err != nil {
+				return jobs, err
+			}
+
+			// Get a new job to load against
+			j, err = openBulkJob(session, options)
+			if err != nil {
+				return jobs, err
+			}
+			jobs = append(jobs, j)
+
+			// Build a new formatter and reset counters
+			f, err = NewFormatter(j, fields)
+			if err != nil {
+				return jobs, err
+			}
+			rollingSize = sizeOfHeaders + sizeOfLineEnding + sizeOfRow + sizeOfLineEnding
+			rollingRowCount = 0
+		}
+		f.Add(v)
+		rollingRowCount++
+	}
+
+	// send the last batch
+	if rollingRowCount > 0 {
+		err = sendDataToJob(j, f)
+		if err != nil {
+			return jobs, err
+		}
+	}
+	return jobs, nil
+}
+
+func sendDataToJob(j *Job, f *Formatter) error {
+	err := j.Upload(f.Reader())
+	if err != nil {
+		return err
+	}
+
+	err = closeBulkJob(j)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func openBulkJob(session session.ServiceFormatter, jobOpts Options) (*Job, error) {
+	resource, err := NewResource(session)
+	if err != nil {
+		return &Job{}, err
+	}
+
+	job, err := resource.CreateJob(jobOpts)
+	if err != nil {
+		return &Job{}, err
+	}
+	return job, nil
+}
+
+func closeBulkJob(job *Job) error {
+	_, err := job.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/bulk/job_simple_test.go
+++ b/bulk/job_simple_test.go
@@ -1,0 +1,1 @@
+package bulk


### PR DESCRIPTION
Add a wrapper func around the lower level bulk actions that automatically opens jobs, sends data to them, and closes them. Chunking the data on the thresholds for the V2 API file size.