### PR TITLE
Bugfix/soql lookup records

### DIFF
--- a/record.go
+++ b/record.go
@@ -92,7 +92,7 @@ func (r *Record) isLookUp(jsonMap map[string]interface{}) bool {
 // LookUps returns all of the record's look ups
 func (r *Record) LookUps() []*Record {
 	records := make([]*Record, len(r.lookUps))
-	idx := 0
+	var idx int
 	for _, r := range r.lookUps {
 		records[idx] = r
 		idx++

--- a/record_test.go
+++ b/record_test.go
@@ -42,6 +42,7 @@ func TestRecord_UnmarshalJSON(t *testing.T) {
 					"Country__c": "Argentina",
 					"Id":         "x01D0000000002RIAQ",
 				},
+				lookUps: map[string]*Record{},
 			},
 			wantErr: false,
 		},
@@ -59,6 +60,48 @@ func TestRecord_UnmarshalJSON(t *testing.T) {
 				fields: map[string]interface{}{
 					"AccountNumber":     "CD656092",
 					"BillingPostalCode": "27215",
+				},
+				lookUps: map[string]*Record{},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "Successfull Decode with look up",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+				{
+					"attributes" : {
+					  "type" : "Customer__x",
+					  "url" : "/services/data/v32.0/sobjects/Customer__x/x01D0000000002RIAQ"
+					},
+					"Country__c" : "Argentina",
+					"Id" : "x01D0000000002RIAQ",
+					"SomeLookup__r": {
+						"attributes": {
+							"type": "SomeLookup__c",
+							"url": "/services/data/v44.0/sobjects/SomeLookup__c/0012E00001q0KijQAE"
+						},
+						"Name": "Salesforce"
+					}
+				  }`),
+			},
+			want: &Record{
+				sobject: "Customer__x",
+				url:     "/services/data/v32.0/sobjects/Customer__x/x01D0000000002RIAQ",
+				fields: map[string]interface{}{
+					"Country__c": "Argentina",
+					"Id":         "x01D0000000002RIAQ",
+				},
+				lookUps: map[string]*Record{
+					"SomeLookup__c": &Record{
+						sobject: "SomeLookup__c",
+						url:     "/services/data/v44.0/sobjects/SomeLookup__c/0012E00001q0KijQAE",
+						fields: map[string]interface{}{
+							"Name": "Salesforce",
+						},
+						lookUps: map[string]*Record{},
+					},
 				},
 			},
 			wantErr: false,
@@ -304,6 +347,7 @@ func TestRecordFromJSONMap(t *testing.T) {
 				fields: map[string]interface{}{
 					"Name": "Test 1",
 				},
+				lookUps: map[string]*Record{},
 			},
 			wantErr: false,
 		},
@@ -325,6 +369,127 @@ func TestRecordFromJSONMap(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("RecordFromJSONMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecord_LookUp(t *testing.T) {
+	type fields struct {
+		sobject string
+		url     string
+		fields  map[string]interface{}
+		lookUps map[string]*Record
+	}
+	type args struct {
+		lookUp string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *Record
+		want1  bool
+	}{
+		{
+			name: "has lookup",
+			fields: fields{
+				lookUps: map[string]*Record{
+					"SomeObject": &Record{
+						sobject: "SomeObject",
+						fields: map[string]interface{}{
+							"Here": true,
+						},
+					},
+				},
+			},
+			args: args{
+				lookUp: "SomeObject",
+			},
+			want: &Record{
+				sobject: "SomeObject",
+				fields: map[string]interface{}{
+					"Here": true,
+				},
+			},
+			want1: true,
+		},
+		{
+			name: "nope",
+			fields: fields{
+				lookUps: map[string]*Record{
+					"SomeObject": &Record{
+						sobject: "SomeObject",
+						fields: map[string]interface{}{
+							"Here": true,
+						},
+					},
+				},
+			},
+			args: args{
+				lookUp: "SomeOther",
+			},
+			want:  nil,
+			want1: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Record{
+				sobject: tt.fields.sobject,
+				url:     tt.fields.url,
+				fields:  tt.fields.fields,
+				lookUps: tt.fields.lookUps,
+			}
+			got, got1 := r.LookUp(tt.args.lookUp)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Record.LookUp() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("Record.LookUp() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestRecord_LookUps(t *testing.T) {
+	type fields struct {
+		sobject string
+		url     string
+		fields  map[string]interface{}
+		lookUps map[string]*Record
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []*Record
+	}{
+		{
+			name: "the look ups",
+			fields: fields{
+				lookUps: map[string]*Record{
+					"LookUps": &Record{
+						sobject: "LookUps",
+					},
+				},
+			},
+			want: []*Record{
+				&Record{
+					sobject: "LookUps",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Record{
+				sobject: tt.fields.sobject,
+				url:     tt.fields.url,
+				fields:  tt.fields.fields,
+				lookUps: tt.fields.lookUps,
+			}
+			if got := r.LookUps(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Record.LookUps() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/soql/record.go
+++ b/soql/record.go
@@ -18,7 +18,7 @@ func newQueryRecord(jsonMap map[string]interface{}, resource *Resource) (*QueryR
 	subresults := make(map[string]*QueryResult)
 	for k, v := range jsonMap {
 		if sub, has := v.(map[string]interface{}); has {
-			if k != sfdc.RecordAttributes {
+			if isSubQuery(sub) {
 				resp, err := newQueryResponseJSON(sub)
 				if err != nil {
 					return nil, err
@@ -52,4 +52,17 @@ func (rec *QueryRecord) Subresults() map[string]*QueryResult {
 func (rec *QueryRecord) Subresult(sub string) (*QueryResult, bool) {
 	result, has := rec.subresults[sub]
 	return result, has
+}
+
+func isSubQuery(jsonMap map[string]interface{}) bool {
+	if _, has := jsonMap["totalSize"]; has == false {
+		return false
+	}
+	if _, has := jsonMap["done"]; has == false {
+		return false
+	}
+	if _, has := jsonMap["records"]; has == false {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Handing Issue #39 

When a query have a look up's fields, then need to handle that as part of an object.  As far as the `SOQL` is concerned, the look up with fields is another record.  It will be treated that way.
```
SELECT LastName, Id, Account.Name, Account.FirstName__c FROM Contact
```
The result will be:
```
    {
            "attributes": {
                "type": "Contact",
                "url": "/services/data/v44.0/sobjects/Contact/0032E00002R7Y3SQAV"
            },
            "LastName": "John Doe",
            "Id": "0032E00002R7Y3SQAV",
            "Account": {
                "attributes": {
                    "type": "Account",
                    "url": "/services/data/v44.0/sobjects/Account/0012E00001q0KijQAE"
                },
                "Name": "Salesforce",
                "FirstName__c": null
            }
        },
```
This PR is backwards compatible with the inner query.