### PR TITLE
Use the field lookup name instead of SObject name

### DIFF
--- a/record.go
+++ b/record.go
@@ -75,7 +75,7 @@ func (r *Record) fromJSONMap(jsonMap map[string]interface{}) {
 				} else {
 					if r.isLookUp(obj) {
 						if rec, err := RecordFromJSONMap(obj); err == nil {
-							r.lookUps[rec.sobject] = rec
+							r.lookUps[k] = rec
 						}
 					}
 				}

--- a/record_test.go
+++ b/record_test.go
@@ -94,7 +94,7 @@ func TestRecord_UnmarshalJSON(t *testing.T) {
 					"Id":         "x01D0000000002RIAQ",
 				},
 				lookUps: map[string]*Record{
-					"SomeLookup__c": &Record{
+					"SomeLookup__r": &Record{
 						sobject: "SomeLookup__c",
 						url:     "/services/data/v44.0/sobjects/SomeLookup__c/0012E00001q0KijQAE",
 						fields: map[string]interface{}{


### PR DESCRIPTION
The lookup on the record used the SObject name as the key for the lookups.  This would cause a conflict if a SObject has multiple lookup fields to the same SObject.  Like the User object.