### PR TITLE
Fix update during Upsert()

### DIFF
--- a/sobject/dml.go
+++ b/sobject/dml.go
@@ -262,7 +262,7 @@ func (d *dml) upsertResponse(request *http.Request) (UpsertValue, error) {
 	var value UpsertValue
 
 	switch response.StatusCode {
-	case http.StatusCreated:
+	case http.StatusCreated, http.StatusOK:
 		defer response.Body.Close()
 		isInsert = true
 		err = decoder.Decode(&value)


### PR DESCRIPTION
Currently, v48.0 Salesforce API returns 200 on a successful update.
Before this fix, Upsert() was returning "upsert response err: 200 200 OK" error during successful update.
Docs - https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_upsert.htm