### PR TITLE
Bug fix: composite payload httpHeaders should be map[string]string instead of map[string][]string

### DIFF
--- a/composite/composite.go
+++ b/composite/composite.go
@@ -158,7 +158,15 @@ func (r *Resource) payload(allOrNone bool, requesters []Subrequester) (*bytes.Re
 			subRequest["body"] = requester.Body()
 		}
 		if requester.HTTPHeaders() != nil {
-			subRequest["httpHeaders"] = requester.HTTPHeaders()
+			salesforceHeaders := map[string]interface{}{}
+			for k, v := range requester.HTTPHeaders() {
+				if len(v) == 1 {
+					salesforceHeaders[k] = v[0]
+				} else {
+					salesforceHeaders[k] = v
+				}
+			}
+			subRequest["httpHeaders"] = salesforceHeaders
 		}
 		subRequests[idx] = subRequest
 	}


### PR DESCRIPTION
Fixes Issue #56

A drawback of this fix is, if the user passes in multiple values for a key, Salesforce would still return an error.

Another possible fix is to change the type of `Subrequester.HTTPHeaders` from `http.Header` to `map[string]string` but we probably don't want to do that because callers may expect to be able to pass in a `http.Header` type for that field.