### PR TITLE
Migrate to golang-jwt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+#### Description
+
+#### Checklist
+
+- [ ] I have resolved all the comments, either here or in real life
+- [ ] I have added automated tests that cover the new behaviour and removed obsolete tests and code

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+
+env:
+  GO111MODULE: on
+  GO_VERSION: "1.19"
+  LINTER_VERSION: "1.50.1"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run linters
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # Required: the version of golangci-lint is required and must be specified without patch version: they always use the latest patch version.
+        version: v${{ env.LINTER_VERSION }}
+        # enable gofmt to check formatting issues
+        args: --enable gofmt
+        # show only new issues if it's a pull request. The default value is `false`.
+        only-new-issues: true
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run tests
+      run: go test -count=1  ./...

--- a/bulk/bulk_test.go
+++ b/bulk/bulk_test.go
@@ -1,7 +1,7 @@
 package bulk
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -74,7 +74,7 @@ func TestResource_CreateJob(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -99,7 +99,7 @@ func TestResource_CreateJob(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -141,7 +141,7 @@ func TestResource_AllJobs(t *testing.T) {
 				return &http.Response{
 					StatusCode: 500,
 					Status:     "Invalid URL",
-					Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+					Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 					Header:     make(http.Header),
 				}
 			}
@@ -171,7 +171,7 @@ func TestResource_AllJobs(t *testing.T) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Status:     "Good",
-				Body:       ioutil.NopCloser(strings.NewReader(resp)),
+				Body:       io.NopCloser(strings.NewReader(resp)),
 				Header:     make(http.Header),
 			}
 		}),

--- a/bulk/job.go
+++ b/bulk/job.go
@@ -558,7 +558,7 @@ func (j *Job) UnprocessedRecords() ([]UnprocessedRecord, error) {
 }
 
 func (j *Job) recordResultHeader(scanner *bufio.Scanner, delimiter string) ([]string, error) {
-	if scanner.Scan() == false {
+	if !scanner.Scan() {
 		return nil, errors.New("job: response needs to have header")
 	}
 	text := strings.Replace(scanner.Text(), "\"", "", -1)

--- a/bulk/job_test.go
+++ b/bulk/job_test.go
@@ -2,7 +2,6 @@ package bulk
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -381,7 +380,7 @@ func TestJob_response(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -425,7 +424,7 @@ func TestJob_response(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Bad",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -481,7 +480,7 @@ func TestJob_createCallout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -506,7 +505,7 @@ func TestJob_createCallout(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -585,7 +584,7 @@ func TestJob_create(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -610,7 +609,7 @@ func TestJob_create(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -671,7 +670,7 @@ func TestJob_setState(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -680,7 +679,7 @@ func TestJob_setState(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -704,7 +703,7 @@ func TestJob_setState(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -746,7 +745,7 @@ func TestJob_setState(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -755,7 +754,7 @@ func TestJob_setState(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -769,7 +768,7 @@ func TestJob_setState(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Bad",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -847,7 +846,7 @@ func TestJob_infoResponse(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -900,7 +899,7 @@ func TestJob_infoResponse(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Bad",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -955,7 +954,7 @@ func TestJob_Info(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -964,7 +963,7 @@ func TestJob_Info(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -996,7 +995,7 @@ func TestJob_Info(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -1073,7 +1072,7 @@ func TestJob_Delete(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -1082,7 +1081,7 @@ func TestJob_Delete(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -1090,7 +1089,7 @@ func TestJob_Delete(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusNoContent,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader("")),
+							Body:       io.NopCloser(strings.NewReader("")),
 							Header:     make(http.Header),
 						}
 
@@ -1112,7 +1111,7 @@ func TestJob_Delete(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -1121,7 +1120,7 @@ func TestJob_Delete(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -1129,7 +1128,7 @@ func TestJob_Delete(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader("")),
+							Body:       io.NopCloser(strings.NewReader("")),
 							Header:     make(http.Header),
 						}
 
@@ -1179,7 +1178,7 @@ func TestJob_Upload(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -1188,7 +1187,7 @@ func TestJob_Upload(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -1196,7 +1195,7 @@ func TestJob_Upload(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusCreated,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader("")),
+							Body:       io.NopCloser(strings.NewReader("")),
 							Header:     make(http.Header),
 						}
 
@@ -1248,7 +1247,7 @@ func TestJob_SuccessfulRecords(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -1257,7 +1256,7 @@ func TestJob_SuccessfulRecords(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -1266,7 +1265,7 @@ func TestJob_SuccessfulRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -1348,7 +1347,7 @@ func TestJob_FailedRecords(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -1357,7 +1356,7 @@ func TestJob_FailedRecords(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -1366,7 +1365,7 @@ func TestJob_FailedRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -1446,7 +1445,7 @@ func TestJob_UnprocessedRecords(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -1455,7 +1454,7 @@ func TestJob_UnprocessedRecords(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid Method",
-								Body:       ioutil.NopCloser(strings.NewReader(req.Method)),
+								Body:       io.NopCloser(strings.NewReader(req.Method)),
 								Header:     make(http.Header),
 							}
 						}
@@ -1464,7 +1463,7 @@ func TestJob_UnprocessedRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 

--- a/bulk/jobs.go
+++ b/bulk/jobs.go
@@ -67,7 +67,7 @@ func (j *Jobs) Records() []Response {
 
 // Next will retrieve the next batch of job information.
 func (j *Jobs) Next() (*Jobs, error) {
-	if j.Done() == true {
+	if j.Done() {
 		return nil, errors.New("jobs: there is no more records")
 	}
 	request, err := j.request(j.response.NextRecordsURL)

--- a/bulk/jobs_test.go
+++ b/bulk/jobs_test.go
@@ -1,7 +1,7 @@
 package bulk
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -55,7 +55,7 @@ func TestJobs_do(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -104,7 +104,7 @@ func TestJobs_do(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Bad",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -144,7 +144,7 @@ func Test_newJobs(t *testing.T) {
 				return &http.Response{
 					StatusCode: 500,
 					Status:     "Invalid URL",
-					Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+					Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 					Header:     make(http.Header),
 				}
 			}
@@ -174,7 +174,7 @@ func Test_newJobs(t *testing.T) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Status:     "Good",
-				Body:       ioutil.NopCloser(strings.NewReader(resp)),
+				Body:       io.NopCloser(strings.NewReader(resp)),
 				Header:     make(http.Header),
 			}
 		}),
@@ -350,7 +350,7 @@ func TestJobs_Next(t *testing.T) {
 				return &http.Response{
 					StatusCode: 500,
 					Status:     "Invalid URL",
-					Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+					Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 					Header:     make(http.Header),
 				}
 			}
@@ -380,7 +380,7 @@ func TestJobs_Next(t *testing.T) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Status:     "Good",
-				Body:       ioutil.NopCloser(strings.NewReader(resp)),
+				Body:       io.NopCloser(strings.NewReader(resp)),
 				Header:     make(http.Header),
 			}
 		}),

--- a/composite/batch/batch.go
+++ b/composite/batch/batch.go
@@ -123,7 +123,7 @@ func (r *Resource) validateSubrequests(requesters []Subrequester) error {
 		if requester.URL() == "" {
 			return errors.New("composite subrequest: must contain a url")
 		}
-		if _, has := validMethods[requester.Method()]; has == false {
+		if _, has := validMethods[requester.Method()]; !has {
 			return errors.New("composite subrequest: empty or invalid method " + requester.Method())
 		}
 	}

--- a/composite/batch/batch_test.go
+++ b/composite/batch/batch_test.go
@@ -2,7 +2,7 @@ package batch
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -216,7 +216,7 @@ func TestResource_Retrieve(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -242,7 +242,7 @@ func TestResource_Retrieve(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -290,7 +290,7 @@ func TestResource_Retrieve(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -305,7 +305,7 @@ func TestResource_Retrieve(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Bad",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 

--- a/composite/composite.go
+++ b/composite/composite.go
@@ -133,7 +133,7 @@ func (r *Resource) validateSubrequests(requesters []Subrequester) error {
 		if requester.ReferenceID() == "" {
 			return errors.New("composite subrequest: must contain a reference id")
 		}
-		if _, has := validMethods[requester.Method()]; has == false {
+		if _, has := validMethods[requester.Method()]; !has {
 			return errors.New("composite subrequest: empty or invalid method " + requester.Method())
 		}
 		if requester.HTTPHeaders() != nil {

--- a/composite/composite_test.go
+++ b/composite/composite_test.go
@@ -1,7 +1,7 @@
 package composite
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -277,7 +277,7 @@ func TestResource_Retrieve(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -344,7 +344,7 @@ func TestResource_Retrieve(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Good",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 
@@ -439,7 +439,7 @@ func TestResource_Retrieve(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Invalid URL",
-								Body:       ioutil.NopCloser(strings.NewReader(req.URL.String())),
+								Body:       io.NopCloser(strings.NewReader(req.URL.String())),
 								Header:     make(http.Header),
 							}
 						}
@@ -454,7 +454,7 @@ func TestResource_Retrieve(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
 							Status:     "Bad",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -27,10 +27,10 @@ type PasswordCredentials struct {
 }
 
 type JwtCredentials struct {
-	URL				string
-	ClientId 		string // the client id as defined in the connected app in SalesForce
-	ClientUsername 	string
-	ClientKey 		*rsa.PrivateKey  // the client RSA key uploaded for authentication in the ConnectedApp
+	URL            string
+	ClientId       string // the client id as defined in the connected app in SalesForce
+	ClientUsername string
+	ClientKey      *rsa.PrivateKey // the client RSA key uploaded for authentication in the ConnectedApp
 }
 
 // Credentials is the structure that contains all of the
@@ -54,7 +54,7 @@ type grantType string
 
 const (
 	passwordGrantType grantType = "password"
-	jwtGrantType grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	jwtGrantType      grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 )
 
 // Retrieve will return the reader for the HTTP request body.
@@ -91,7 +91,9 @@ func NewPasswordCredentials(creds PasswordCredentials) (*Credentials, error) {
 
 // NewJWTCredentials weill create a credntial with all required info about generating a JWT claims parameter
 func NewJWTCredentials(creds JwtCredentials) (*Credentials, error) {
-	if err := validateJWTCredentials(creds); err != nil {return nil, err}
+	if err := validateJWTCredentials(creds); err != nil {
+		return nil, err
+	}
 	return &Credentials{
 		provider: &jwtProvider{
 			creds: creds,

--- a/credentials/jwt.go
+++ b/credentials/jwt.go
@@ -2,11 +2,12 @@ package credentials
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
 	"io"
 	"net/url"
 	"strings"
 	"time"
+
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 const (
@@ -18,7 +19,7 @@ type jwtProvider struct {
 }
 
 type claims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 func (provider *jwtProvider) Retrieve() (io.Reader, error) {
@@ -46,12 +47,12 @@ func (provider *jwtProvider) GetAppropriateExpirationTime() int64 {
 // builds the actual claims token required for authentication
 func (provider *jwtProvider) BuildClaimsToken(expirationTime int64, url string, clientId string, clientUsername string) (string, error) {
 	claims := &claims{
-		StandardClaims: jwt.StandardClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
 			// In JWT, the expiry time is expressed as unix milliseconds
-			ExpiresAt: expirationTime,
-			Audience:  url,                  // "https://test.salesforce.com" || "https://login.salesforce.com"
-			Issuer:    clientId, // consumer key of the connected app, hardcoded
-			Subject:   clientUsername,                       // username of the salesforce user, whose profile is added to the connected app
+			ExpiresAt: jwt.NewNumericDate(time.Unix(expirationTime, 0)),
+			Audience:  []string{url},  // "https://test.salesforce.com" || "https://login.salesforce.com"
+			Issuer:    clientId,       // consumer key of the connected app, hardcoded
+			Subject:   clientUsername, // username of the salesforce user, whose profile is added to the connected app
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/credentials/jwt_test.go
+++ b/credentials/jwt_test.go
@@ -1,24 +1,13 @@
 package credentials
 
 import (
-	"github.com/dgrijalva/jwt-go"
-	"io"
-	"net/url"
-	"strings"
 	"testing"
+
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 const SampleKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m\n0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa\niks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO\nlh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV\nZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1\noSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad\n4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA\nOntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC\nqJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I\neK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5\ntog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH\n5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q\n+smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ\nN1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK\nP/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP\n+dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP\nyWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5\nPI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm\nQKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE\n2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge\nLDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq\nNGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW\nRHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ\nGqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo\nhQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg\n-----END RSA PRIVATE KEY-----"
 
-
-
-func mockJWTRetriveReader(creds JwtCredentials) io.Reader {
-	form := url.Values{}
-	form.Add("grant_type", string(jwtGrantType))
-
-
-	return strings.NewReader(form.Encode())
-}
 func Test_jwtProvider_Retrieve(t *testing.T) {
 
 	pemData := []byte(SampleKey)
@@ -39,13 +28,13 @@ func Test_jwtProvider_Retrieve(t *testing.T) {
 			name: "Token Retriever",
 			fields: fields{
 				creds: JwtCredentials{
-					URL:          "http://test.password.session",
-					ClientId:     "12345",
-					ClientUsername:     "myusername",
-					ClientKey: signKey,
+					URL:            "http://test.password.session",
+					ClientId:       "12345",
+					ClientUsername: "myusername",
+					ClientKey:      signKey,
 				},
 			},
-			want: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwOi8vdGVzdC5wYXNzd29yZC5zZXNzaW9uIiwiZXhwIjoxMjMyMTMsImlzcyI6IjEyMzQ1Iiwic3ViIjoibXl1c2VybmFtZSJ9.rMwIVIG9IEHuZ9O5Na3VZHCRTw0z7iBRugWPlZeq6VFjcrHimDvBxN91DQtQcOqULSORWvo0HGzEHo_LOnMopj6dyL-wxgEp3Fu9owv-69HNP_uYYfy0_W93-1BVlOgCGuF6NdP2JHb3EsUmEPf-DJcjYmiymUMrMV6vNhkbl3eb_V93xA4-sid4reyMyBDVznKqyrQOOiyEqEq3tF9IZKcu7Cr1KDJa2br8S9Rq_xwv6PZPm4Pm97Bpd5t95Fo6zyTIOLu-zaXRzwKBRF6StuXsisfXo66-jDnSs0R-fx_RaI6GRez900lEzqZK13ggsLmB3PqpNcZkWvKvExBSHg",
+			want:    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxMjM0NSIsInN1YiI6Im15dXNlcm5hbWUiLCJhdWQiOlsiaHR0cDovL3Rlc3QucGFzc3dvcmQuc2Vzc2lvbiJdLCJleHAiOjEyMzIxM30.vPXbMQJoVx3OXOGedx4xmzeElL8dSa04aYvWwhUbyQGV9I2ODvN-dLin1WWT1afWtVNhkJQyGP4-_XnC9XKvok9xJ19e1daOLLjOliMsQ676pW016QzONOjtTRr4nhOl6juaOUvWGW2EKVve4HREz5WLJrc96pWsYt_dlv6hpDBUCwNZ60xHTMMOMK-Rz9e-kce3RahGZopcD6AyHvhtzNBRp1qYqMQTVrH87ePeY755ncLgt37eCaamlE_CqAXrTIcC36KSFFw3XZ9hWM7YXnGTP8HF1ZxnEeSY9DPk9v_nNrhFo4i-qkZ78f8sPqi7WW-J04LWjk6-8Y-ujj8XVw",
 			wantErr: false,
 		},
 	}
@@ -57,11 +46,11 @@ func Test_jwtProvider_Retrieve(t *testing.T) {
 			token, err := provider.BuildClaimsToken(123213, provider.creds.URL, provider.creds.ClientId, provider.creds.ClientUsername)
 
 			if err != nil && !tt.wantErr {
-				t.Error()
+				t.Error(err)
 			}
 
 			if token != tt.want {
-				t.Error("tokens do not match")
+				t.Error("tokens do not match, expected: ", tt.want, " got: ", token)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/g8rswimmer/go-sfdc
+
+go 1.19
+
+require github.com/golang-jwt/jwt/v4 v4.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/record.go
+++ b/record.go
@@ -70,7 +70,7 @@ func (r *Record) fromJSONMap(jsonMap map[string]interface{}) {
 			}
 		} else {
 			if v != nil {
-				if obj, is := v.(map[string]interface{}); is == false {
+				if obj, is := v.(map[string]interface{}); !is {
 					r.fields[k] = v
 				} else {
 					if r.isLookUp(obj) {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3,7 +3,7 @@ package session
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -70,7 +70,7 @@ func TestPasswordSessionRequest(t *testing.T) {
 					t.Errorf("%s URL not matching %s :: %s", scenario.desc, scenario.creds.URL+oauthEndpoint, request.URL.String())
 				}
 
-				buf, err := ioutil.ReadAll(request.Body)
+				buf, err := io.ReadAll(request.Body)
 				request.Body.Close()
 				if err != nil {
 					t.Fatal(err.Error())
@@ -79,7 +79,7 @@ func TestPasswordSessionRequest(t *testing.T) {
 				if err != nil {
 					t.Fatal(err.Error())
 				}
-				body, err := ioutil.ReadAll(reader)
+				body, err := io.ReadAll(reader)
 				if err != nil {
 					t.Fatal(err.Error())
 				}
@@ -117,7 +117,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(strings.NewReader(resp)),
+					Body:       io.NopCloser(strings.NewReader(resp)),
 					Header:     make(http.Header),
 				}
 			}),
@@ -138,7 +138,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 				return &http.Response{
 					StatusCode: http.StatusInternalServerError,
 					Status:     "Some status",
-					Body:       ioutil.NopCloser(strings.NewReader("")),
+					Body:       io.NopCloser(strings.NewReader("")),
 					Header:     make(http.Header),
 				}
 			}),
@@ -161,7 +161,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(strings.NewReader(resp)),
+					Body:       io.NopCloser(strings.NewReader(resp)),
 					Header:     make(http.Header),
 				}
 			}),
@@ -257,7 +257,7 @@ func TestNewPasswordSession(t *testing.T) {
 
 					return &http.Response{
 						StatusCode: 200,
-						Body:       ioutil.NopCloser(strings.NewReader(resp)),
+						Body:       io.NopCloser(strings.NewReader(resp)),
 						Header:     make(http.Header),
 					}
 				}),
@@ -312,7 +312,7 @@ func TestNewPasswordSession(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
 						Status:     "Some status",
-						Body:       ioutil.NopCloser(strings.NewReader("")),
+						Body:       io.NopCloser(strings.NewReader("")),
 						Header:     make(http.Header),
 					}
 				}),

--- a/sobject/collections/collections.go
+++ b/sobject/collections/collections.go
@@ -116,7 +116,7 @@ func (r *Resource) Query(sobject string, records []sobject.Querier) ([]*sfdc.Rec
 		return nil, err
 	}
 
-	if matching == false {
+	if !matching {
 		return nil, fmt.Errorf("collection resource: %s is not a valid sobject", sobject)
 	}
 

--- a/sobject/collections/collections_test.go
+++ b/sobject/collections/collections_test.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -51,7 +50,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -60,7 +59,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -71,7 +70,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "No one value",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -80,7 +79,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "No two value",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -94,7 +93,7 @@ func Test_collection_send(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -123,7 +122,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -132,7 +131,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -143,7 +142,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "No one value",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -152,7 +151,7 @@ func Test_collection_send(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "No two value",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -168,7 +167,7 @@ func Test_collection_send(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusConflict,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -282,7 +281,7 @@ func TestResource_Update(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad URL: " + req.URL.String(),
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -291,7 +290,7 @@ func TestResource_Update(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad Method",
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -318,7 +317,7 @@ func TestResource_Update(t *testing.T) {
 							return &http.Response{
 								StatusCode: http.StatusOK,
 								Status:     "Some Status",
-								Body:       ioutil.NopCloser(strings.NewReader(resp)),
+								Body:       io.NopCloser(strings.NewReader(resp)),
 								Header:     make(http.Header),
 							}
 						}),
@@ -428,7 +427,7 @@ func TestResource_Query(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad URL: " + req.URL.String(),
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -437,7 +436,7 @@ func TestResource_Query(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad Method",
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -466,7 +465,7 @@ func TestResource_Query(t *testing.T) {
 							return &http.Response{
 								StatusCode: http.StatusOK,
 								Status:     "Some Status",
-								Body:       ioutil.NopCloser(strings.NewReader(resp)),
+								Body:       io.NopCloser(strings.NewReader(resp)),
 								Header:     make(http.Header),
 							}
 						}),
@@ -570,7 +569,7 @@ func TestResource_Insert(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad URL: " + req.URL.String(),
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -579,7 +578,7 @@ func TestResource_Insert(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad Method",
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -606,7 +605,7 @@ func TestResource_Insert(t *testing.T) {
 							return &http.Response{
 								StatusCode: http.StatusOK,
 								Status:     "Some Status",
-								Body:       ioutil.NopCloser(strings.NewReader(resp)),
+								Body:       io.NopCloser(strings.NewReader(resp)),
 								Header:     make(http.Header),
 							}
 						}),
@@ -718,7 +717,7 @@ func TestResource_Delete(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad URL: " + req.URL.String(),
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -727,7 +726,7 @@ func TestResource_Delete(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Bad Method",
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -738,7 +737,7 @@ func TestResource_Delete(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "allOrNone",
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -747,7 +746,7 @@ func TestResource_Delete(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "ids",
-									Body:       ioutil.NopCloser(strings.NewReader("resp")),
+									Body:       io.NopCloser(strings.NewReader("resp")),
 									Header:     make(http.Header),
 								}
 							}
@@ -773,7 +772,7 @@ func TestResource_Delete(t *testing.T) {
 							return &http.Response{
 								StatusCode: http.StatusOK,
 								Status:     "Some Status",
-								Body:       ioutil.NopCloser(strings.NewReader(resp)),
+								Body:       io.NopCloser(strings.NewReader(resp)),
 								Header:     make(http.Header),
 							}
 						}),

--- a/sobject/collections/delete_test.go
+++ b/sobject/collections/delete_test.go
@@ -1,7 +1,7 @@
 package collections
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -83,7 +83,7 @@ func TestDelete_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -92,7 +92,7 @@ func TestDelete_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -103,7 +103,7 @@ func TestDelete_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "allOrNone",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -112,7 +112,7 @@ func TestDelete_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "ids",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -138,7 +138,7 @@ func TestDelete_Callout(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/collections/insert_test.go
+++ b/sobject/collections/insert_test.go
@@ -1,7 +1,7 @@
 package collections
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -103,7 +103,7 @@ func TestInsert_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -112,7 +112,7 @@ func TestInsert_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -139,7 +139,7 @@ func TestInsert_Callout(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/collections/query_test.go
+++ b/sobject/collections/query_test.go
@@ -1,7 +1,7 @@
 package collections
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -196,7 +196,7 @@ func TestQuery_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -205,7 +205,7 @@ func TestQuery_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -234,7 +234,7 @@ func TestQuery_Callout(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/collections/update_test.go
+++ b/sobject/collections/update_test.go
@@ -1,7 +1,7 @@
 package collections
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -107,7 +107,7 @@ func TestUpdate_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -116,7 +116,7 @@ func TestUpdate_Callout(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -143,7 +143,7 @@ func TestUpdate_Callout(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/describe_test.go
+++ b/sobject/describe_test.go
@@ -1,7 +1,7 @@
 package sobject
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -54,7 +54,7 @@ func Test_describe_Describe(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -77,7 +77,7 @@ func Test_describe_Describe(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -254,7 +254,7 @@ func Test_describe_Describe(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/dml_test.go
+++ b/sobject/dml_test.go
@@ -1,7 +1,7 @@
 package sobject
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -67,7 +67,7 @@ func Test_dml_Insert(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -103,7 +103,7 @@ func Test_dml_Insert(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -132,7 +132,7 @@ func Test_dml_Insert(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusCreated,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -165,7 +165,7 @@ func Test_dml_Insert(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusCreated,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -270,7 +270,7 @@ func Test_dml_Update(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -397,7 +397,7 @@ func Test_dml_Upsert(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -435,7 +435,7 @@ func Test_dml_Upsert(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -466,7 +466,7 @@ func Test_dml_Upsert(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusCreated,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -501,7 +501,7 @@ func Test_dml_Upsert(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusCreated,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/framework.go
+++ b/sobject/framework.go
@@ -70,7 +70,7 @@ func (r *Resources) Metadata(sobject string) (MetadataValue, error) {
 		return MetadataValue{}, err
 	}
 
-	if matching == false {
+	if !matching {
 		return MetadataValue{}, fmt.Errorf("sobject salesforce api: %s is not a valid sobject", sobject)
 	}
 
@@ -88,7 +88,7 @@ func (r *Resources) Describe(sobject string) (DescribeValue, error) {
 		return DescribeValue{}, err
 	}
 
-	if matching == false {
+	if !matching {
 		return DescribeValue{}, fmt.Errorf("sobject salesforce api: %s is not a valid sobject", sobject)
 	}
 
@@ -187,7 +187,7 @@ func (r *Resources) DeletedRecords(sobject string, startDate, endDate time.Time)
 		return DeletedRecords{}, err
 	}
 
-	if matching == false {
+	if !matching {
 		return DeletedRecords{}, fmt.Errorf("sobject salesforce api: %s is not a valid sobject", sobject)
 	}
 
@@ -205,7 +205,7 @@ func (r *Resources) UpdatedRecords(sobject string, startDate, endDate time.Time)
 		return UpdatedRecords{}, err
 	}
 
-	if matching == false {
+	if !matching {
 		return UpdatedRecords{}, fmt.Errorf("sobject salesforce api: %s is not a valid sobject", sobject)
 	}
 

--- a/sobject/metadata_test.go
+++ b/sobject/metadata_test.go
@@ -1,7 +1,7 @@
 package sobject
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -55,7 +55,7 @@ func Test_metadata_Metadata(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -78,7 +78,7 @@ func Test_metadata_Metadata(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -139,7 +139,7 @@ func Test_metadata_Metadata(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/query.go
+++ b/sobject/query.go
@@ -3,7 +3,7 @@ package sobject
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -352,7 +352,7 @@ func (q *query) contentResponse(request *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("deleted records response err: %d %s", response.StatusCode, response.Status)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	defer response.Body.Close()
 
 	return body, err

--- a/sobject/query_test.go
+++ b/sobject/query_test.go
@@ -2,7 +2,7 @@ package sobject
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -27,12 +27,6 @@ func (mock *mockQuery) ID() string {
 }
 func (mock *mockQuery) Fields() []string {
 	return mock.fields
-}
-
-type mockRecord struct {
-	sobject string
-	url     string
-	fields  map[string]interface{}
 }
 
 func testNewRecord(data []byte) *sfdc.Record {
@@ -93,7 +87,7 @@ func Test_query_Query(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -129,7 +123,7 @@ func Test_query_Query(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -159,7 +153,7 @@ func Test_query_Query(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -192,7 +186,7 @@ func Test_query_Query(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -297,7 +291,7 @@ func Test_query_ExternalQuery(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -334,7 +328,7 @@ func Test_query_ExternalQuery(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -365,7 +359,7 @@ func Test_query_ExternalQuery(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -399,7 +393,7 @@ func Test_query_ExternalQuery(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -482,7 +476,7 @@ func Test_query_DeletedRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -503,13 +497,13 @@ func Test_query_DeletedRecords(t *testing.T) {
 					url: "https://test.salesforce.com",
 					client: mockHTTPClient(func(req *http.Request) *http.Response {
 
-						if strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Account/deleted/?") == false {
+						if !strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Account/deleted/?") {
 							t.Errorf("Urls do not match %s", req.URL.String())
 						}
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -540,7 +534,7 @@ func Test_query_DeletedRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -565,7 +559,7 @@ func Test_query_DeletedRecords(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -600,7 +594,7 @@ func Test_query_DeletedRecords(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -685,7 +679,7 @@ func Test_query_UpdatedRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -706,13 +700,13 @@ func Test_query_UpdatedRecords(t *testing.T) {
 					url: "https://test.salesforce.com",
 					client: mockHTTPClient(func(req *http.Request) *http.Response {
 
-						if strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Account/updated/?") == false {
+						if !strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Account/updated/?") {
 							t.Errorf("Urls do not match %s", req.URL.String())
 						}
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -743,7 +737,7 @@ func Test_query_UpdatedRecords(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -768,7 +762,7 @@ func Test_query_UpdatedRecords(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -801,7 +795,7 @@ func Test_query_UpdatedRecords(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -880,7 +874,7 @@ func Test_query_GetContent(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -900,13 +894,13 @@ func Test_query_GetContent(t *testing.T) {
 					url: "https://test.salesforce.com",
 					client: mockHTTPClient(func(req *http.Request) *http.Response {
 
-						if strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Attachment/001D000000INjVe/body") == false {
+						if !strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Attachment/001D000000INjVe/body") {
 							t.Errorf("Urls do not match %s", req.URL.String())
 						}
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -926,13 +920,13 @@ func Test_query_GetContent(t *testing.T) {
 					url: "https://test.salesforce.com",
 					client: mockHTTPClient(func(req *http.Request) *http.Response {
 
-						if strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Document/001D000000INjVe/body") == false {
+						if !strings.HasPrefix(req.URL.String(), "https://test.salesforce.com/sobjects/Document/001D000000INjVe/body") {
 							t.Errorf("Urls do not match %s", req.URL.String())
 						}
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -955,7 +949,7 @@ func Test_query_GetContent(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/sobject/tree/builder.go
+++ b/sobject/tree/builder.go
@@ -32,7 +32,7 @@ func NewRecordBuilder(builder Builder) (*RecordBuilder, error) {
 	if err != nil {
 		return nil, err
 	}
-	if matching == false {
+	if !matching {
 		return nil, fmt.Errorf("tree builder: %s is not a valid sobject", sobject)
 	}
 	if builder.ReferenceID() == "" {

--- a/sobject/tree/tree.go
+++ b/sobject/tree/tree.go
@@ -60,7 +60,7 @@ func (r *Resource) Insert(inserter Inserter) (*Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	if matching == false {
+	if !matching {
 		return nil, fmt.Errorf("tree resourse: %s is not a valid sobject", sobject)
 	}
 

--- a/sobject/tree/tree_test.go
+++ b/sobject/tree/tree_test.go
@@ -1,7 +1,7 @@
 package tree
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -88,7 +88,7 @@ func TestResource_Insert(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("resp")),
+							Body:       io.NopCloser(strings.NewReader("resp")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -129,7 +129,7 @@ func TestResource_Insert(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -138,7 +138,7 @@ func TestResource_Insert(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -155,7 +155,7 @@ func TestResource_Insert(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusCreated,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -204,7 +204,7 @@ func TestResource_Insert(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad URL: " + req.URL.String(),
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -213,7 +213,7 @@ func TestResource_Insert(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Bad Method",
-								Body:       ioutil.NopCloser(strings.NewReader("resp")),
+								Body:       io.NopCloser(strings.NewReader("resp")),
 								Header:     make(http.Header),
 							}
 						}
@@ -234,7 +234,7 @@ func TestResource_Insert(t *testing.T) {
 						return &http.Response{
 							StatusCode: http.StatusCreated,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/soql/formatter.go
+++ b/soql/formatter.go
@@ -9,17 +9,17 @@ import (
 
 // QueryInput is used to provide SOQL inputs.
 //
-// ObjectType is the Salesforce Object, like Account
+// # ObjectType is the Salesforce Object, like Account
 //
-// FieldList is the Salesforce Object's fields to query
+// # FieldList is the Salesforce Object's fields to query
 //
-// SubQuery is the inner query
+// # SubQuery is the inner query
 //
-// Where is the SOQL where cause
+// # Where is the SOQL where cause
 //
-// Order is the SOQL ordering
+// # Order is the SOQL ordering
 //
-// Limit is the SOQL record limit
+// # Limit is the SOQL record limit
 //
 // Offset is the SOQL record offset
 type QueryInput struct {
@@ -152,12 +152,11 @@ func WhereGreaterThan(field string, value interface{}, equals bool) (*WhereClaus
 		return nil, errors.New("soql where: value can not be nil")
 	}
 	var v string
-	switch value.(type) {
+	switch value := value.(type) {
 	case string, bool:
 		return nil, errors.New("where greater than: value can not be a string or bool")
 	case time.Time:
-		date := value.(time.Time)
-		v = date.Format(time.RFC3339)
+		v = value.Format(time.RFC3339)
 	default:
 		v = fmt.Sprintf("%v", value)
 	}
@@ -182,12 +181,11 @@ func WhereLessThan(field string, value interface{}, equals bool) (*WhereClause, 
 		return nil, errors.New("soql where: value can not be nil")
 	}
 	var v string
-	switch value.(type) {
+	switch value := value.(type) {
 	case string, bool:
 		return nil, errors.New("where less than: value can not be a string")
 	case time.Time:
-		date := value.(time.Time)
-		v = date.Format(time.RFC3339)
+		v = value.Format(time.RFC3339)
 	default:
 		v = fmt.Sprintf("%v", value)
 	}
@@ -209,12 +207,11 @@ func WhereEquals(field string, value interface{}) (*WhereClause, error) {
 	}
 	var v string
 	if value != nil {
-		switch value.(type) {
+		switch value := value.(type) {
 		case string:
-			v = fmt.Sprintf("'%s'", value.(string))
+			v = fmt.Sprintf("'%s'", value)
 		case time.Time:
-			date := value.(time.Time)
-			v = date.Format(time.RFC3339)
+			v = value.Format(time.RFC3339)
 		default:
 			v = fmt.Sprintf("%v", value)
 		}
@@ -234,12 +231,11 @@ func WhereNotEquals(field string, value interface{}) (*WhereClause, error) {
 	}
 	var v string
 	if value != nil {
-		switch value.(type) {
+		switch value := value.(type) {
 		case string:
-			v = fmt.Sprintf("'%s'", value.(string))
+			v = fmt.Sprintf("'%s'", value)
 		case time.Time:
-			date := value.(time.Time)
-			v = date.Format(time.RFC3339)
+			v = value.Format(time.RFC3339)
 		default:
 			v = fmt.Sprintf("%v", value)
 		}
@@ -262,14 +258,13 @@ func WhereIn(field string, values []interface{}) (*WhereClause, error) {
 	}
 	set := make([]string, len(values))
 	for idx, value := range values {
-		switch value.(type) {
+		switch value := value.(type) {
 		case string:
-			set[idx] = fmt.Sprintf("'%s'", value.(string))
+			set[idx] = fmt.Sprintf("'%s'", value)
 		case bool:
 			return nil, errors.New("where in: boolean is not a value set value")
 		case time.Time:
-			date := value.(time.Time)
-			set[idx] = date.Format(time.RFC3339)
+			set[idx] = value.Format(time.RFC3339)
 		default:
 			set[idx] = fmt.Sprintf("%v", value)
 		}
@@ -290,14 +285,13 @@ func WhereNotIn(field string, values []interface{}) (*WhereClause, error) {
 	}
 	set := make([]string, len(values))
 	for idx, value := range values {
-		switch value.(type) {
+		switch value := value.(type) {
 		case string:
-			set[idx] = fmt.Sprintf("'%s'", value.(string))
+			set[idx] = fmt.Sprintf("'%s'", value)
 		case bool:
 			return nil, errors.New("where not in: boolean is not a value set value")
 		case time.Time:
-			date := value.(time.Time)
-			set[idx] = date.Format(time.RFC3339)
+			set[idx] = value.Format(time.RFC3339)
 		default:
 			set[idx] = fmt.Sprintf("%v", value)
 		}

--- a/soql/query_test.go
+++ b/soql/query_test.go
@@ -1,7 +1,7 @@
 package soql
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -102,7 +102,7 @@ func TestResource_Query(t *testing.T) {
 						return &http.Response{
 							StatusCode: 500,
 							Status:     "Some Status",
-							Body:       ioutil.NopCloser(strings.NewReader("Error")),
+							Body:       io.NopCloser(strings.NewReader("Error")),
 							Header:     make(http.Header),
 						}
 					}),
@@ -125,7 +125,7 @@ func TestResource_Query(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -147,7 +147,7 @@ func TestResource_Query(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Some Status",
-								Body:       ioutil.NopCloser(strings.NewReader("Error")),
+								Body:       io.NopCloser(strings.NewReader("Error")),
 								Header:     make(http.Header),
 							}
 						}
@@ -178,7 +178,7 @@ func TestResource_Query(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),
@@ -274,7 +274,7 @@ func TestResource_next(t *testing.T) {
 							return &http.Response{
 								StatusCode: 500,
 								Status:     "Some Status",
-								Body:       ioutil.NopCloser(strings.NewReader("Error")),
+								Body:       io.NopCloser(strings.NewReader("Error")),
 								Header:     make(http.Header),
 							}
 						}
@@ -305,7 +305,7 @@ func TestResource_next(t *testing.T) {
 
 						return &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(strings.NewReader(resp)),
+							Body:       io.NopCloser(strings.NewReader(resp)),
 							Header:     make(http.Header),
 						}
 					}),

--- a/soql/record.go
+++ b/soql/record.go
@@ -55,13 +55,13 @@ func (rec *QueryRecord) Subresult(sub string) (*QueryResult, bool) {
 }
 
 func isSubQuery(jsonMap map[string]interface{}) bool {
-	if _, has := jsonMap["totalSize"]; has == false {
+	if _, has := jsonMap["totalSize"]; !has {
 		return false
 	}
-	if _, has := jsonMap["done"]; has == false {
+	if _, has := jsonMap["done"]; !has {
 		return false
 	}
-	if _, has := jsonMap["records"]; has == false {
+	if _, has := jsonMap["records"]; !has {
 		return false
 	}
 	return true

--- a/soql/result.go
+++ b/soql/result.go
@@ -52,7 +52,7 @@ func (result *QueryResult) Records() []*QueryRecord {
 
 // Next will query the next set of records.
 func (result *QueryResult) Next() (*QueryResult, error) {
-	if result.MoreRecords() == false {
+	if !result.MoreRecords() {
 		return nil, errors.New("soql query result: no more records to query")
 	}
 	return result.resource.next(result.response.NextRecordsURL)

--- a/soql/result_test.go
+++ b/soql/result_test.go
@@ -1,7 +1,7 @@
 package soql
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -308,7 +308,7 @@ func TestQueryResult_Next(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Some Status",
-									Body:       ioutil.NopCloser(strings.NewReader("Error")),
+									Body:       io.NopCloser(strings.NewReader("Error")),
 									Header:     make(http.Header),
 								}
 							}
@@ -339,7 +339,7 @@ func TestQueryResult_Next(t *testing.T) {
 
 							return &http.Response{
 								StatusCode: 200,
-								Body:       ioutil.NopCloser(strings.NewReader(resp)),
+								Body:       io.NopCloser(strings.NewReader(resp)),
 								Header:     make(http.Header),
 							}
 						}),


### PR DESCRIPTION
- migrate to golang-jwt  (as it is recommended by previous maintainer of jwt pkg)
- add dependabot for regular security checks
- add PR template
- add CI on top of GH Actions
- fix many linter offenses